### PR TITLE
feat: Don't display `OpenAI` models when no key

### DIFF
--- a/lua/gptmodels/util.lua
+++ b/lua/gptmodels/util.lua
@@ -20,7 +20,7 @@ end
 
 -- Log to the file debug.log in the root. File can be watched for easier debugging.
 M.log = function(...)
-  local args = {...}
+  local args = { ... }
 
   -- Canonical log dir
   local data_path = vim.fn.stdpath("data") .. "/gptmodels"
@@ -120,6 +120,12 @@ M.get_visual_selection = function()
   selection.text = text
 
   return selection
+end
+
+---@param env_key string
+---@return boolean
+M.ensure_env_var = function(env_key)
+  return type(os.getenv(env_key)) ~= type(nil)
 end
 
 return M

--- a/lua/gptmodels/windows/chat.lua
+++ b/lua/gptmodels/windows/chat.lua
@@ -175,6 +175,12 @@ function M.build_and_mount(selected_text)
     end
   end)
 
+  -- Show models only if openai key
+  has_openai_key = util.ensure_env_var("OPENAI_API_KEY")
+  if not has_openai_key then
+    Store.llm_models.openai = {}
+  end
+
   -- Input window is text with no syntax
   vim.bo[input.bufnr].filetype = 'txt'
   vim.bo[input.bufnr].syntax = ''

--- a/lua/gptmodels/windows/code.lua
+++ b/lua/gptmodels/windows/code.lua
@@ -203,6 +203,12 @@ function M.build_and_mount(selected_lines)
     end
   end)
 
+  -- Show models only if openai key
+  has_openai_key = util.ensure_env_var("OPENAI_API_KEY")
+  if not has_openai_key then
+    Store.llm_models.openai = {}
+  end
+
   -- Turn off syntax highlighting for input buffer.
   vim.bo[input.bufnr].filetype = "txt"
   vim.bo[input.bufnr].syntax = ""

--- a/tests/gpt/util_spec.lua
+++ b/tests/gpt/util_spec.lua
@@ -107,4 +107,17 @@ describe("util", function()
       assert.is_true(res.text ~= nil)
     end)
   end)
+
+  describe("ensure_env_var", function()
+    it("returns true", function()
+      -- always set
+      local res = util.ensure_env_var("SHELL")
+      assert.is_true(res)
+    end)
+
+    it("returns false", function()
+      local res = util.ensure_env_var("I_DONT_EXIST_WOO")
+      assert.is_false(res)
+    end)
+  end)
 end)

--- a/tests/gpt/windows/chat_spec.lua
+++ b/tests/gpt/windows/chat_spec.lua
@@ -590,7 +590,7 @@ describe("The Chat window", function()
   end)
 
   it("fetches ollama llms when started", function()
-    local first_openai_model = Store.llm_models.openai[1]
+    local first_ollama_model = "your-model"
 
     local fetch_models_stub = stub(ollama, "fetch_models")
 
@@ -608,12 +608,12 @@ describe("The Chat window", function()
     -- their local ollama)
     assert.equal("my-model", Store.llm_model)
 
-    -- Now ensure if we end up on an openai model, we will stay there on subsequent open
-    Store.llm_model = first_openai_model
+    -- Now ensure if we end up on an ollama model, we will stay there on subsequent open
+    Store.llm_model = first_ollama_model
 
     chat_window.build_and_mount()
     assert.stub(fetch_models_stub).was_called(2)
-    assert.equal(first_openai_model, Store.llm_model)
+    assert.equal(first_ollama_model, Store.llm_model)
   end)
 
   it("alerts the user when required programs are not installed", function()
@@ -659,5 +659,4 @@ describe("The Chat window", function()
     local chat_lines = vim.api.nvim_buf_get_lines(chat.chat.bufnr, 0, -1, true)
     assert(util.contains_line(chat_lines, "curl error"))
   end)
-
 end)

--- a/tests/gpt/windows/code_spec.lua
+++ b/tests/gpt/windows/code_spec.lua
@@ -704,6 +704,35 @@ describe("The code window", function()
     assert.equal(expected_scroll, actual_scroll)
   end)
 
+  it("if no OpenAI key, don't have openai llms", function()
+    -- FIX: Why is this not being populated?
+    local openai_llms = Store.llm_models.openai
+
+    -- set to true, hence should not have anything set
+    local ensure_env_var_stub = stub(util, "ensure_env_var")
+    ensure_env_var_stub.invokes(function()
+      return false
+    end)
+
+    code_window.build_and_mount()
+
+    assert.stub(ensure_env_var_stub).was_called(1)
+    assert.is_true(next(Store.llm_models.openai) == nil)
+
+    -- reset store
+    Store.llm_models.openai = openai_llms
+
+    -- returns true (we have an openai key)
+    ensure_env_var_stub.invokes(function()
+      return true
+    end)
+
+    -- Now, ensure openai models are available
+    code_window.build_and_mount()
+    assert.stub(ensure_env_var_stub).was_called(2)
+    assert.is_true(next(Store.llm_models.openai) ~= nil)
+  end)
+
   it("fetches ollama llms when started", function()
     local first_openai_model = Store.llm_models.openai[1]
 


### PR DESCRIPTION
Summary:
- Add a utility function to check environment variable for OpenAI key
- Add tests for the utility function
- Add a check to code/chat windows to hide the display
- TODO: Fix tests in chat_spec/code_spec lua files

Resolves #1 